### PR TITLE
Fix CloudFront deployment in non-us-east-1 regions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.aws-sam/
+client/dist/
+node_modules/

--- a/client/public/weights/.gitignore
+++ b/client/public/weights/.gitignore
@@ -1,0 +1,4 @@
+# Ignore all contents of this folder (recursively), but keep this gitignore file:
+*
+*/
+!.gitignore

--- a/template.yaml
+++ b/template.yaml
@@ -7,11 +7,28 @@ Resources:
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
+        - ServerSideEncryptionByDefault:
+            SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
 
   StaticWebsiteBucket:
     Type: AWS::S3::Bucket
+    Properties:
+      CorsConfiguration:
+        CorsRules:
+          - Id: AllowAll
+            AllowedMethods:
+              - GET
+              - HEAD
+            AllowedOrigins:
+              - '*'
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: index.html
 
   ChallengesTable:
     Type: AWS::Serverless::SimpleTable
@@ -101,7 +118,7 @@ Resources:
         DefaultRootObject: index.html
         Enabled: true
         Origins:
-          - DomainName: !Sub "${StaticWebsiteBucket}.s3.amazonaws.com"
+          - DomainName: !Sub "${StaticWebsiteBucket}.s3.${AWS::Region}.amazonaws.com"
             Id: the-s3-bucket
             S3OriginConfig:
               OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}"


### PR DESCRIPTION
**Issue #, if available:** #5

**Description of changes:**

- Add a region specifier to the CloudFront S3 origin DomainName, without which the distribution does not work correctly outside of `us-east-1`
- Tighten up security posture of the frames bucket with additional public access blocks
- Set website configurations on the website bucket, in case users want to explore serving without CloudFront
- Fix up some gitignores to keep workspaces tidy

**Testing done:**

- Confirmed the updated solution deploys & works in both `us-east-1` and `ap-southeast-1`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
